### PR TITLE
Stop using the removed `style` key

### DIFF
--- a/sphinx_typlog_theme/layout.html
+++ b/sphinx_typlog_theme/layout.html
@@ -26,7 +26,7 @@
     <link rel="search" type="application/opensearchdescription+xml" title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}" href="{{ pathto('_static/opensearch.xml', 1) }}"/>
   {%- endif %}
   {%- include "style.html" -%}
-  <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}?v={{ theme_version }}" type="text/css" />
+  <link rel="stylesheet" href="{{ pathto('_static/' + styles[-1], 1) }}?v={{ theme_version }}" type="text/css" />
   <link rel="stylesheet" href="{{ pathto('_static/theme.css', 1) }}?v={{ theme_version }}" type="text/css" />
   {%- for cssfile in css_files -%}
     <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />


### PR DESCRIPTION
key `style` has been removed from Sphinx 7. Instead, use `styles[-1]`.  See: https://github.com/sphinx-doc/sphinx/pull/11381